### PR TITLE
Add docker files for mssql bak file to avro

### DIFF
--- a/src/main/docker/docker_mssqlbak-to-avro/Dockerfile
+++ b/src/main/docker/docker_mssqlbak-to-avro/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/mssql/server:2019-latest
+USER root
+
+#install java 8
+RUN apt-get update
+RUN apt-get -y install openjdk-8-jre
+
+# Create work directory
+RUN mkdir -p /usr/work
+WORKDIR /usr/work
+
+# Copy entrypoint.sh, mssql-restore.sh scripts into working directory
+COPY entrypoint.sh /usr/work/
+COPY run_mssqlrestore.sh /usr/work/
+#bak file should be mounted on a volume
+#COPY $BAKFILE /usr/work/
+
+# Copy files used for db-to-avro
+COPY db-to-avro-2.0.jar /usr/work/db-to-avro.jar
+COPY local.properties /usr/work
+COPY run-db2avro.sh /usr/work/
+
+# Grant permissions for the scripts to be executable
+RUN chmod u+x mssql-restore.sh
+RUN chmod u+x run-db2avro.sh
+
+EXPOSE 1433:1433
+CMD /bin/bash ./entrypoint.sh
+

--- a/src/main/docker/docker_mssqlbak-to-avro/README
+++ b/src/main/docker/docker_mssqlbak-to-avro/README
@@ -1,0 +1,23 @@
+This docker produces avro files from a specified bak file.  The avro files are produced by first
+restoring the bak file to an mssql instance.  Please ensure that there is sufficient memory for the
+mssql instance as well as the bak file that is being restored.
+
+To use:
+1) Ensure that you have enough disk space for mssql instance + bak file restore.  Start with 50G for modest size backup.
+
+2) Update run_docker.sh with the following. The LOCAL_SRC and LOCAL_DEST directories will be mounted in the docker container.
+	- BAKFILE - name of bakfile without the path
+	- LOCAL_SRC - path to the BAKFILE
+	- LOCAL_DEST - directory for the avro files
+
+3) Copy db-to-avro-2.0.jar into this directory
+
+4) Run from this directory
+	sudo ./docker-run.sh
+
+5) To track progess
+	sudo docker logs mssqlbak_avro -f
+
+6) To dump container logs at the end
+	sudo docker logs mssqlbak_avro > $YOUR_LOGFILE
+

--- a/src/main/docker/docker_mssqlbak-to-avro/docker-run.sh
+++ b/src/main/docker/docker_mssqlbak-to-avro/docker-run.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#this file should be run as sudo
+
+LOCAL_SRC_DIR=/home/eloh/bak
+LOCAL_DEST_DIR=/home/eloh/avro_echo
+BAKFILE=echo_20220718.bak
+
+#this is the password used for the docker mssql instance
+SA_PASSWORD=Rest0re!
+
+has_image=`docker image ls | grep bak2avro`
+if [ -z "$has_image"]; then
+	docker build -t mssqlbak2avro .
+fi
+
+cp ../../../target/db-to-avro-2.0.jar .
+
+docker run --rm -d \
+	-e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SA_PASSWORD" \
+	-e BAKFILE="$BAKFILE" \
+	--name mssqlbak_avro \
+	-v ${LOCAL_SRC_DIR}:/bak \
+	-v ${LOCAL_DEST_DIR}:/avro \
+	-p 1433:1433 mssqlbak2avro

--- a/src/main/docker/docker_mssqlbak-to-avro/entrypoint.sh
+++ b/src/main/docker/docker_mssqlbak-to-avro/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/work/run_mssqlrestore.sh & /opt/mssql/bin/sqlservr

--- a/src/main/docker/docker_mssqlbak-to-avro/local.properties
+++ b/src/main/docker/docker_mssqlbak-to-avro/local.properties
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2021 The Board of Trustees of The Leland Stanford Junior University.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+
+# Application defaults, can be overridden by a job
+#
+# Note ${UUID} is substituted everywhere with the same random UUID at startup time
+
+# Docker host for managing containers
+docker.host=unix:///var/run/docker.sock
+
+# Specify network for spawned container
+docker.container.network.mode=bridge
+
+# IP address to use if the above is not "bridge"
+docker.container.network.ipv4addr=10.10.10.100
+
+# Make sure this is at least # threads computed below, or you will get Hikari connection timeouts
+database.pool.size=64
+
+# MS SQL Server defaults
+#these are being set in the command line
+#sqlserver.database.url=jdbc:sqlserver://sqlserver:1433;user=SA;password=xxxxx;database=master;autoCommit=false
+#sqlserver.database.user=SA
+#sqlserver.database.password=
+#sqlserver.image=mcr.microsoft.com/mssql/server:latest-ubuntu
+#sqlserver.mounts=/data/mssql:/var/opt/mssql
+sqlserver.env=ACCEPT_EULA=Y,SA_PASSWORD=
+sqlserver.ports=1433:1433
+
+avro.filename=%{SCHEMA}.%{TABLE}-%{PART}.avro
+avro.logfile=job.json
+
+# Options after this line may be overridden by command-line
+date.string=true
+date.string.suffix=__dt_str
+
+# Avro compression (uncompressed, snappy, deflate)
+avro.codec=snappy
+
+# Target size for generated Avro files, based on *uncompressed* source table bytes.
+# Set to zero for unlimited file size.
+avro.size=1000000000
+
+# Maximum number of rows to fetch per DB query
+fetch.row.count=2000
+
+# Normalize & lowercase table names (columns always normalized & lowercased)
+tidy.table.names=true
+
+#exclude table -- not sure if this is working
+exclude-table=sysdiagrams

--- a/src/main/docker/docker_mssqlbak-to-avro/mssql-restore.sh
+++ b/src/main/docker/docker_mssqlbak-to-avro/mssql-restore.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+SA_PASSWORD=${SA_PASSWORD:-Restore!}
+BAKFILE=${BAKFILE:-echo.bak}
+
+echo "Waiting for the SQL Server to come up"
+sleep 120s
+
+echo "Copying /bak/$BAKFILE to /var/opt/mssql/backup/restore.bak"
+mkdir -p /var/opt/mssql/backup
+cp /bak/$BAKFILE /var/opt/mssql/backup/restore.bak
+
+#get the list of databases to restore.
+databases=($(/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "${SA_PASSWORD}" -Q "RESTORE FILELISTONLY FROM DISK = '/var/opt/mssql/backup/restore.bak'" | head -n -2 | sed 1,2d | awk '{print $1}'))
+dbfiles=($(/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "${SA_PASSWORD}" -Q "RESTORE FILELISTONLY FROM DISK = '/var/opt/mssql/backup/restore.bak'" | head -n -2 | sed 1,2d | awk '{print $4}' | awk 'BEGIN{FS="\\"}{print $NF}'))
+
+echo "Databases from bak file to restore: $databases"
+
+MVSTR=""
+for i in ${!databases[@]}; do
+    MVSTR=$MVSTR"MOVE '${databases[$i]}' TO '/var/opt/mssql/data/${dbfiles[$i]}',"
+done
+
+MVSTR=$(echo $MVSTR | sed 's/,$//')
+
+echo "Moving ... $MVSTR"
+/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "${SA_PASSWORD}" -Q "RESTORE DATABASE RestoreDb FROM DISK = '/var/opt/mssql/backup/restore.bak' WITH $MVSTR"
+
+# extract data to avro files
+echo "Extracting to avro files"
+/usr/work/run-db2avro.sh

--- a/src/main/docker/docker_mssqlbak-to-avro/run-db2avro.sh
+++ b/src/main/docker/docker_mssqlbak-to-avro/run-db2avro.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#this file should be run as sudo
+SA_PASSWORD=${SA_PASSWORD:-Rest0re!}
+
+#exclude-table option is not working
+java -jar /usr/work/db-to-avro.jar --connect="jdbc:sqlserver://localhost:1433;user=SA;password=${SA_PASSWORD};database=master;autoCommit=false" --user="SA" --password="${SA_PASSWORD}" --flavor=sqlserver --catalog=RestoreDb --schema=dbo --destination=/avro --exclude-table=sysdiag --log-file=/avro/${BAKFILE}_av.log

--- a/src/main/java/com/github/susom/starr/dbtoavro/functions/impl/SqlServerDatabaseFns.java
+++ b/src/main/java/com/github/susom/starr/dbtoavro/functions/impl/SqlServerDatabaseFns.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import jdk.internal.org.jline.reader.Completer;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Adds scripts and Dockerfile to create an mssql instance in a docker container, restore the bak file and dump the data from the bak file as avro files.